### PR TITLE
GameWindowクラスをrecordで実装からクラスで実装するように変更して,初期画面が何も表示されない問題を解決できました。

### DIFF
--- a/src/main/java/game/Main.java
+++ b/src/main/java/game/Main.java
@@ -1,34 +1,11 @@
 package game;
 
-import factory.ConcreteGameElementFactory;
-import factory.GameElementFactory;
 import window.GameWindow;
-
-import javax.swing.*;
-import java.awt.*;
 
 public class Main {
     public static void main(String[] args) {
 
-        GameElementFactory factory = new ConcreteGameElementFactory();
-
-        // ウィンドウ作成
-        JFrame window = factory.createFrame();
-        Container con = window.getContentPane();
-        JPanel titleNamePanel = factory.createPanel();
-        JPanel startButtonPanel = factory.createStartButtonPanel();
-        JPanel mainTextPanel = factory.createMainTextPanel();
-        JLabel titleNameLabel = factory.createLabel("TOWER BATTLE");
-        JButton startButton = factory.createButton("スタート");
-        JTextArea mainTextArea = factory.createTextArea("これはメインのテキストエリア");
-        Font titleFont = factory.createFont();
-        Font normalFont = factory.createNormalFont();
-
-        GameWindow gameWindow = new GameWindow(factory, con,
-                titleNamePanel, startButtonPanel, mainTextPanel,
-                titleNameLabel, startButton, mainTextArea, titleFont,
-                normalFont);
-
+        GameWindow gameWindow = new GameWindow();
         gameWindow.frame();
     }
 }

--- a/src/main/java/handler/TitleScreenHandler.java
+++ b/src/main/java/handler/TitleScreenHandler.java
@@ -1,0 +1,20 @@
+package handler;
+
+import window.GameWindow;
+
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+
+public class TitleScreenHandler implements ActionListener {
+
+    GameWindow gameWindow;
+
+    public TitleScreenHandler(GameWindow gameWindow) {
+        this.gameWindow = gameWindow;
+    }
+
+    @Override
+    public void actionPerformed(ActionEvent e) {
+        gameWindow.createGameScreen();
+    }
+}

--- a/src/main/java/window/GameWindow.java
+++ b/src/main/java/window/GameWindow.java
@@ -1,25 +1,34 @@
 package window;
 
+import factory.ConcreteGameElementFactory;
 import factory.GameElementFactory;
+import handler.TitleScreenHandler;
 
 import javax.swing.*;
 import java.awt.*;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 
-public record GameWindow(GameElementFactory factory,
-                         Container con,
-                         JPanel titleNamePanel,
-                         JPanel startButtonPanel,
-                         JPanel mainTextPanel,
-                         JLabel titleNameLabel,
-                         JButton startButton,
-                         JTextArea mainTextArea,
-                         Font titleFont,
-                         Font normalFont) implements Window, ActionListener {
+public class GameWindow implements Window {
+
+    GameElementFactory factory = new ConcreteGameElementFactory();
+
+    // ウィンドウ作成
+    JFrame window;
+    Container con;
+    JPanel titleNamePanel = factory.createPanel();
+    JPanel startButtonPanel = factory.createStartButtonPanel();
+    JPanel mainTextPanel = factory.createMainTextPanel();
+    JLabel titleNameLabel = factory.createLabel("TOWER BATTLE");
+    JButton startButton = factory.createButton("スタート");
+    JTextArea mainTextArea = factory.createTextArea("これはメインのテキストエリア");
+    Font titleFont = factory.createFont();
+    Font normalFont = factory.createNormalFont();
+    TitleScreenHandler tsHandler = new TitleScreenHandler(this);
 
     @Override
     public void frame() {
+
+        window = factory.createFrame();
+        con = window.getContentPane();
 
         // タイトルパネル作成
         titleNamePanel.setBounds(factory.createSize() + 52, factory.createSize() + 32,
@@ -35,7 +44,7 @@ public record GameWindow(GameElementFactory factory,
 
         // スタートボタン作成
         startButton.setFont(normalFont);
-        startButton.addActionListener(this);
+        startButton.addActionListener(tsHandler);
 
         // ウィンドウに貼り付け
         titleNamePanel.add(titleNameLabel);
@@ -60,10 +69,5 @@ public record GameWindow(GameElementFactory factory,
         mainTextArea.setFont(normalFont);
         mainTextArea.setLineWrap(true);
         mainTextPanel.add(mainTextArea);
-    }
-
-    @Override
-    public void actionPerformed(ActionEvent e) {
-        createGameScreen();
     }
 }


### PR DESCRIPTION
# 実装されたGameWindowクラス内でオーバーライドされたframeメソッド内 
# 30行目window = factory.createFrame();
# 31行目con = window.getContentPane();
この２つのインスタンスを省いた状態で、フィールドとして、定義しておくと、実行した時に表示された画面は真っ暗なままでした。
<br>
それはなぜそうなるのか、おそらくコンポーネントの階層が無効化されているんじゃないかと推測に至りました。
<br>
画面サイズをマウスで縮小拡大したときに表示されてスタートボタンクリックして画面が切り替わりゲームのメインパネルも表示されるのは,アクションリスナーのイベントがマウスでクリックしたときに発生して,その時にコンポーネントの階層が表示されているんじゃないかと思いました。

<br>

GameWindowクラスをrecordで実装してしまうとインスタンスのデータの情報はイミュータブルになってしまうので,GameWindowクラスの2８行目の `@Override`されたframeメソッド内でインスタンス変数はすべてfinalなので再代入できないため,30行目window = factory.createFrame(); 31行目con = window.getContentPane();のような書き方はできないです。


<br>

実行した時に表示された画面は真っ暗なままの状態(バグの状態)

https://github.com/user-attachments/assets/57432963-fe93-40a3-98a1-08e1882df5fb


実行した時にタイトル画面が表示される(バグが解決された状態)

https://github.com/user-attachments/assets/a485fda6-1e08-40d0-9788-b15374999476

変更点

![image](https://github.com/user-attachments/assets/6567e32a-039e-401f-938e-e7f981970a90)

![image](https://github.com/user-attachments/assets/66fc9b61-a9d1-4404-a9ca-34398dbddaa3)

![image](https://github.com/user-attachments/assets/c67b8a1b-a604-4513-8e2a-6e3c436bc6ba)

![image](https://github.com/user-attachments/assets/2541dff6-f510-4942-be6f-19f8e6b9123f)







